### PR TITLE
Update filter usage with params in get_items_list

### DIFF
--- a/directus/directus.py
+++ b/directus/directus.py
@@ -186,7 +186,7 @@ class DirectusClient:
             "offset": offset,
             "sort": ",".join(sort),
             "single": single,
-            "filter": filter,
+            **filter,
             "status": status,
             "q": q,
         }


### PR DESCRIPTION
I wasn't able to filter items, because the API is expecting filter clause to be in the form like in the [documentation](https://docs.directus.io/api/query/filter.html), for example:

GET /items/projects?**filter[category][eq]=development**&**filter[category][logical]=or&filter[category][like]=design**

As is will throw exception:
GET /items/records?fields=*&limit=100&offset=0&sort=id&single=False&**filter=filter[dataset_id][eq]&filter=filter[id][eq]**&meta=